### PR TITLE
Modality DICOM find fixes, better array handling

### DIFF
--- a/lib/orthanc/modalities.rb
+++ b/lib/orthanc/modalities.rb
@@ -24,33 +24,69 @@ module Orthanc
     end
 
     # POST /modalities/{dicom}/echo
-    def echo(payload = {}) # C-Echo SCU
-      handle_response(base_uri["echo"].post(payload))
+    def echo(payload = {}) # C-Echo SCU. Return true if successful
+      base_uri["echo"].post(payload){|response, request, result, &block|
+        if response.code == 200
+          return true
+        else
+          return false
+        end
+      }
     end
 
     # POST /modalities/{dicom}/find
-    def find(payload = {})
-      handle_response(base_uri["find"].post(payload))
+    def find(payload = {}) # C-Echo SCU. Return true if successful
+      rsp = base_uri["find"].post(payload){|response, request, result, &block|
+        if response.code == 200
+          return rsp
+        else
+          return false
+        end
+      }
     end
 
     # POST /modalities/{dicom}/find-patient
-    def find_patient(payload = {})
-      handle_response(base_uri["find-patient"].post(payload))
+    def find_patient(payload = {}) # eg. '{"PatientName":"JOD*","PatientSex":"M"}'
+      rsp = base_uri["find-patient"].post(payload){|response, request, result, &block|
+        if response.code == 200
+          return rsp
+        else
+          return false
+        end
+      }
     end
 
     # POST /modalities/{dicom}/find-series
-    def find_series(payload = {})
-      handle_response(base_uri["find-series"].post(payload))
+    def find_series(payload = {}) # eg. '{"PatientID":"0555643F"}'
+      rsp = base_uri["find-series"].post(payload){|response, request, result, &block|
+        if response.code == 200
+          return rsp
+        else
+          return false
+        end
+      }
     end
 
     # POST /modalities/{dicom}/find-study
-    def find_study(payload = {})
-      handle_response(base_uri["find-study"].post(payload))
+    def find_study(payload = {}) # eg. '{"PatientID":"0555643F","StudyInstanceUID":"1.2.840.113704.1.111.2768.1239195678.57"}'
+      rsp = base_uri["find-study"].post(payload){|response, request, result, &block|
+        if response.code == 200
+          return rsp
+        else
+          return false
+        end
+      }
     end
 
     # POST /modalities/{dicom}/store
     def store(payload = {}) # POST body = UUID series, UUID instance, or raw DICOM file
-      handle_response(base_uri["store"].post(payload))
+      base_uri["store"].post(payload){|response, request, result, &block|
+        if response.code == 200
+          return true
+        else
+          return false
+        end
+      }
     end
 
   end

--- a/lib/orthanc/modalities.rb
+++ b/lib/orthanc/modalities.rb
@@ -36,9 +36,9 @@ module Orthanc
 
     # POST /modalities/{dicom}/find
     def find(payload = {}) # C-Echo SCU. Return true if successful
-      rsp = base_uri["find"].post(payload){|response, request, result, &block|
+      base_uri["find"].post(payload){|response, request, result, &block|
         if response.code == 200
-          return rsp
+          return handle_response(response)
         else
           return false
         end
@@ -47,9 +47,9 @@ module Orthanc
 
     # POST /modalities/{dicom}/find-patient
     def find_patient(payload = {}) # eg. '{"PatientName":"JOD*","PatientSex":"M"}'
-      rsp = base_uri["find-patient"].post(payload){|response, request, result, &block|
+      base_uri["find-patient"].post(payload){|response, request, result, &block|
         if response.code == 200
-          return rsp
+          return handle_response(response)
         else
           return false
         end
@@ -58,9 +58,9 @@ module Orthanc
 
     # POST /modalities/{dicom}/find-series
     def find_series(payload = {}) # eg. '{"PatientID":"0555643F"}'
-      rsp = base_uri["find-series"].post(payload){|response, request, result, &block|
+      base_uri["find-series"].post(payload){|response, request, result, &block|
         if response.code == 200
-          return rsp
+          return handle_response(response)
         else
           return false
         end
@@ -69,9 +69,9 @@ module Orthanc
 
     # POST /modalities/{dicom}/find-study
     def find_study(payload = {}) # eg. '{"PatientID":"0555643F","StudyInstanceUID":"1.2.840.113704.1.111.2768.1239195678.57"}'
-      rsp = base_uri["find-study"].post(payload){|response, request, result, &block|
+      base_uri["find-study"].post(payload){|response, request, result, &block|
         if response.code == 200
-          return rsp
+          return handle_response(response)
         else
           return false
         end

--- a/lib/orthanc/response.rb
+++ b/lib/orthanc/response.rb
@@ -16,7 +16,11 @@ module Response
         parsed_response = JSON.parse(response)
 
         if parsed_response.class == Array
-          return parsed_response
+          # Normalize to an array inside a hash, so RecursiveOpenStruct can act
+          data = {}
+          data["response"] = parsed_response
+          return RecursiveOpenStruct.new(data.to_snake_keys, recurse_over_arrays: true ).response
+
         elsif parsed_response.class == Hash
           return RecursiveOpenStruct.new(parsed_response.to_snake_keys, recurse_over_arrays: true )
         else

--- a/lib/orthanc/version.rb
+++ b/lib/orthanc/version.rb
@@ -1,4 +1,4 @@
 module Orthanc
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
   ORTHANC_API_VERSION = "0.8.6"
 end


### PR DESCRIPTION
- Fixed exception handling for `modalities(id).find`, `.find-patient`, `.find-series` and `.find-studies` when network operations fail. Now they return `false` on error 500 
- Better array handling, now normalizes Arrays to a Hash and _then_ transforms with `RecursiveOpenStruct`, to be able to apply `.to_snake_keys`  to all responses.
